### PR TITLE
Use provided SkiaSharp library

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -9,7 +9,6 @@ pkgbase = muse-sounds-manager-bin
 	depends = fontconfig
 	depends = zlib
 	depends = hicolor-icon-theme
-	depends = skia-sharp
 	provides = muse-sounds-manager=2.0.4.872
 	conflicts = muse-hub
 	replaces = muse-hub

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -10,7 +10,7 @@ license=(custom:muse-sounds-manager)
 provides=("$_pkgname=$pkgver")
 replaces=('muse-hub')
 conflicts=('muse-hub')
-depends=('fontconfig' 'zlib' 'hicolor-icon-theme' 'skia-sharp')
+depends=('fontconfig' 'zlib' 'hicolor-icon-theme')
 makedepends=()
 install="$_pkgname.install"
 source=("_$pkgname-$pkgver.tar.gz::https://muse-cdn.com/Muse_Sounds_Manager_x64.tar.gz" 'LICENSE')
@@ -32,7 +32,6 @@ package(){
   mkdir -p "$pkgdir/usr/share/icons"
 
   cp bin/* "$pkgdir/opt/muse-sounds-manager/"
-  rm "$pkgdir/opt/muse-sounds-manager/libSkiaSharp.so"
 
   ln -s /opt/muse-sounds-manager/muse-sounds-manager "$pkgdir/usr/bin/muse-sounds-manager"
 


### PR DESCRIPTION
Resolves #6 

It seems that there is a problem when using the external library where muse-sounds-manager refuses to launch. Using the library provided by muse fixes this.